### PR TITLE
Adding Site Daily Metrics code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: python
+python:
+  - "2.7"
+
+# command to install dependencies
+install:
+  - pip install -r devsite/requirements.txt
+
+# command to run tests
+scripts:
+  - py.test
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,9 @@ python:
 # command to install dependencies
 install:
   - pip install -r devsite/requirements.txt
+  - pip install pytest-cov
 
 # command to run tests
 script:
-  - py.test
-
+  - py.test --cov=./
+  - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ install:
   - pip install -r devsite/requirements.txt
 
 # command to run tests
-scripts:
+script:
   - py.test
 

--- a/devsite/devsite/settings.py
+++ b/devsite/devsite/settings.py
@@ -24,7 +24,7 @@ SECRET_KEY = 'b=q!%oog)*yufj8q562+_latcva*d#t&!&w4=_i30)lr2_obha'
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
-
+USE_TZ = True
 ALLOWED_HOSTS = []
 
 

--- a/devsite/devsite/test_settings.py
+++ b/devsite/devsite/test_settings.py
@@ -52,6 +52,8 @@ ROOT_URLCONF = 'edx_figures.urls'
 
 SECRET_KEY = 'insecure-secret-key'
 
+USE_TZ = True
+
 # https://wsvincent.com/django-rest-framework-serializers-viewsets-routers/
 
 # For initial testing, later we want to enforce authorization

--- a/devsite/requirements.txt
+++ b/devsite/requirements.txt
@@ -10,7 +10,7 @@
 ###
 
 python-dateutil==2.1
-
+path.py==11.0
 ##
 ## Django package dependencies
 ##

--- a/devsite/requirements.txt
+++ b/devsite/requirements.txt
@@ -5,19 +5,34 @@
 
 # Versions should match those used in Open edX Ginkgo
 
+##
+## General Python package dependencies
+###
+
+python-dateutil==2.1
+
+##
+## Django package dependencies
+##
+
 Django==1.8.12
 django-extensions==1.5.9
 djangorestframework==3.2.3
 django-countries==4.0
 django-filter==0.11.0
 django-webpack-loader==0.5.0
-
 django-model-utils==2.3.1
+
+##
+## Open edX package dependencies
+##
+
 edx-opaque-keys==0.4
 #edx-drf-extensions==1.2.2
 
-
-# Pytest dependencies
+##
+## Pytest dependencies
+##
 
 factory-boy==2.5.1
 pylint==1.8.2

--- a/edx_figures/admin.py
+++ b/edx_figures/admin.py
@@ -1,3 +1,15 @@
 from django.contrib import admin
 
 # Register your models here.
+
+from .models import (
+    SiteDailyMetrics,
+
+    )
+
+@admin.register(SiteDailyMetrics)
+class SiteDailyMetricsAdmin(admin.ModelAdmin):
+    list_display = ( 'id', 'date_for', 'cumulative_active_user_count',
+        'todays_active_user_count', 'total_user_count',
+        'course_count', 'total_enrollment_count',
+        )

--- a/edx_figures/filters.py
+++ b/edx_figures/filters.py
@@ -64,10 +64,20 @@ class UserFilter(django_filters.FilterSet):
         fields = ['username', 'email', 'country', 'is_active', 'is_staff',
                   'is_superuser', ]
 
+
 class SiteDailyMetricsFilter(django_filters.FilterSet):
     '''Provides filtering for the SiteDailyMetrics model objects
 
+    This is a work in progress. Parameters need improvement, but have to dive
+    into Django Filter more
+
+    Use ``date_for`` for retrieving a specific date
+    Use ``date_0`` and ``date_1`` for retrieving values in a date range, inclusive
+    each of these can be used singly to get:
+    * ``date_0`` to get records greater than or equal
+    * ``date_1`` to get records less than or equal
     '''
+    date = django_filters.DateFromToRangeFilter(name='date_for')
     class Meta:
         model = SiteDailyMetrics
-        fields = ['date_for']
+        fields = ['date_for', 'date']

--- a/edx_figures/filters.py
+++ b/edx_figures/filters.py
@@ -9,6 +9,8 @@ from openedx.core.djangoapps.content.course_overviews.models import (
     CourseOverview,
 )
 
+from edx_figures.models import SiteDailyMetrics
+
 
 class CourseOverviewFilter(django_filters.FilterSet):
     '''Provides filtering for CourseOverview model objects
@@ -61,3 +63,11 @@ class UserFilter(django_filters.FilterSet):
         model = get_user_model()
         fields = ['username', 'email', 'country', 'is_active', 'is_staff',
                   'is_superuser', ]
+
+class SiteDailyMetricsFilter(django_filters.FilterSet):
+    '''Provides filtering for the SiteDailyMetrics model objects
+
+    '''
+    class Meta:
+        model = SiteDailyMetrics
+        fields = ['date_for']

--- a/edx_figures/migrations/0001_initial.py
+++ b/edx_figures/migrations/0001_initial.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.utils.timezone
+import model_utils.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='SiteDailyMetrics',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('created', model_utils.fields.AutoCreatedField(default=django.utils.timezone.now, verbose_name='created', editable=False)),
+                ('modified', model_utils.fields.AutoLastModifiedField(default=django.utils.timezone.now, verbose_name='modified', editable=False)),
+                ('date_for', models.DateField(unique=True)),
+                ('cumulative_active_user_count', models.IntegerField(null=True, blank=True)),
+                ('todays_active_user_count', models.IntegerField(null=True, blank=True)),
+                ('total_user_count', models.IntegerField()),
+                ('course_count', models.IntegerField()),
+                ('total_enrollment_count', models.IntegerField()),
+            ],
+            options={
+                'ordering': ['-date_for'],
+            },
+        ),
+    ]

--- a/edx_figures/models.py
+++ b/edx_figures/models.py
@@ -4,3 +4,31 @@ Defines edx-figures models
 '''
 
 from django.db import models
+from django.utils.encoding import python_2_unicode_compatible
+
+from model_utils.models import TimeStampedModel
+
+
+@python_2_unicode_compatible
+class SiteDailyMetrics(TimeStampedModel):
+    '''
+    TODO: Add Multi-site support
+    add FK to site and make site + date_for unique together
+    '''
+
+    # Date for which this record's data are collected
+    date_for = models.DateField(unique=True)
+    cumulative_active_user_count = models.IntegerField(blank=True, null=True)
+    todays_active_user_count = models.IntegerField(blank=True, null=True)
+    total_user_count = models.IntegerField()
+    course_count = models.IntegerField()
+    total_enrollment_count = models.IntegerField()
+
+    # Foreign key relationships
+    # site = 
+
+    class Meta:
+        ordering = ['-date_for']
+
+    def __str__(self):
+        return "{} {}".format(self.id, self.date_for)

--- a/edx_figures/serializers.py
+++ b/edx_figures/serializers.py
@@ -4,6 +4,8 @@
 
 from rest_framework import serializers
 
+from .models import SiteDailyMetrics
+
 ###
 ### Summary serializers for listing
 ###
@@ -23,8 +25,6 @@ class CourseIndexSerializer(serializers.Serializer):
     number = serializers.CharField(source='display_number_with_default')
 
 
-
-
 class UserIndexSerializer(serializers.Serializer):
     '''Provides a limited set of user information for summary display
     '''
@@ -32,3 +32,11 @@ class UserIndexSerializer(serializers.Serializer):
     username = serializers.CharField(read_only=True)
     fullname = serializers.CharField(source='profile.name', default=None,
         read_only=True)
+
+
+class SiteDailyMetricsSerializer(serializers.ModelSerializer):
+    '''Proviedes summary data about the LMS site
+    '''
+
+    class Meta:
+        model = SiteDailyMetrics

--- a/edx_figures/urls.py
+++ b/edx_figures/urls.py
@@ -2,9 +2,18 @@
 edx-figures URL definitions
 '''
 
-from django.conf.urls import url
+from django.conf.urls import include, url
+from rest_framework import routers
 
 from . import views
+
+router = routers.DefaultRouter()
+
+router.register(
+    r'site-daily-metrics',
+    views.SiteDailyMetricsViewSet,
+    base_name='site-daily-metrics')
+
 
 urlpatterns = [
 
@@ -12,6 +21,7 @@ urlpatterns = [
     url(r'^$', views.edx_figures_home, name='edx-figures-home'),
 
     # REST API
+    url(r'^api/', include(router.urls, namespace='api')),
     url(r'^api/courses-index/', views.CoursesIndexView.as_view(),
         name='courses-index'),
     url(r'^api/user-index/', views.UserIndexView.as_view(), name='user-index'),

--- a/edx_figures/views.py
+++ b/edx_figures/views.py
@@ -5,6 +5,7 @@ from django.contrib.auth import get_user_model
 from django.db.models import F
 from django.shortcuts import render
 
+from rest_framework import viewsets
 from rest_framework.generics import ListAPIView
 from rest_framework.permissions import IsAuthenticated
 
@@ -17,10 +18,11 @@ from openedx.core.djangoapps.content.course_overviews.models import (
 )
 from student.models import UserProfile
 
-from .filters import CourseOverviewFilter, UserFilter
-
+from .filters import CourseOverviewFilter, SiteDailyMetricsFilter, UserFilter
+from .models import SiteDailyMetrics
 from .serializers import (
     CourseIndexSerializer,
+    SiteDailyMetricsSerializer,
     UserIndexSerializer,
 )
 
@@ -43,6 +45,10 @@ def edx_figures_home(request):
     }
     return render(request, 'edx_figures/index.html', context)
 
+
+##
+## Views for data in edX platform
+##
 
 # We're going straight to the model so that we ensure we
 # are getting the behavior we want.
@@ -99,3 +105,23 @@ class UserIndexView(ListAPIView):
         queryset = super(UserIndexView, self).get_queryset()
 
         return queryset
+
+##
+## Views for edX Figures models
+##
+
+#class SiteDailyMetricsViewSet(CommonAuthMixin, viewsets.ModelViewSet):
+class SiteDailyMetricsViewSet(viewsets.ModelViewSet):
+
+    model = SiteDailyMetrics
+    queryset = SiteDailyMetrics.objects.all()
+    pagination_class = None
+    serializer_class = SiteDailyMetricsSerializer
+    filter_backends = (DjangoFilterBackend, )
+    filter_class = SiteDailyMetricsFilter
+
+    def get_queryset(self):
+        queryset = super(SiteDailyMetricsViewSet, self).get_queryset()
+        return queryset
+
+        #return SiteDailyMetricsQuery.get_queryset(self.request.query_params)

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,9 +1,13 @@
-'''
-Helpers to generate fixtures for testing.
+'''Helpers to generate model instances for testing.
+
+Defines model factories for edX Figures, edX platform, and other models that we
+need to create for our tests.
 
 Uses Factory Boy: https://factoryboy.readthedocs.io/en/latest/
 
 '''
+
+import datetime
 
 from django.contrib.auth import get_user_model
 #from django_countries.fields import CountryField
@@ -16,6 +20,8 @@ from openedx.core.djangoapps.content.course_overviews.models import (
 
 from student.models import UserProfile
 from lms.djangoapps.teams.models import CourseTeam, CourseTeamMembership
+
+from edx_figures.models import SiteDailyMetrics
 
 
 class CourseOverviewFactory(DjangoModelFactory):
@@ -60,8 +66,7 @@ class UserFactory(DjangoModelFactory):
     is_active = True
     is_staff = False
 
-    profile = factory.RelatedFactory(UserProfileFactory,
-        'user',)
+    profile = factory.RelatedFactory(UserProfileFactory, 'user')
 
     @factory.post_generation
     def teams(self, create, extracted, **kwargs):
@@ -71,3 +76,18 @@ class UserFactory(DjangoModelFactory):
         if extracted:
             for team in extracted:
                 self.teams.add(team)
+
+
+##
+## edX Figures model factories
+##
+
+class SiteDailyMetricsFactory(DjangoModelFactory):
+    class Meta:
+        model = SiteDailyMetrics
+    date_for = factory.Sequence(lambda n: datetime.date(2018, 1, 1) + datetime.timedelta(days=n))
+    cumulative_active_user_count = factory.Sequence(lambda n: n)
+    total_user_count = factory.Sequence(lambda n: n)
+    course_count = factory.Sequence(lambda n: n)
+    total_enrollment_count = factory.Sequence(lambda n: n)
+    #site = factory.RelatedFactory(SiteFactory, 'site')

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,59 @@
+'''
+Test models declared in edX Figures
+'''
+
+import datetime
+import pytest
+
+from edx_figures.models import SiteDailyMetrics
+
+from .factories import SiteDailyMetricsFactory
+
+
+@pytest.mark.django_db
+class TestSiteDailyMetrics(object):
+    '''Unit tests for  the SiteDailyMetrics model
+
+    Focus on testing SiteDailyMetrics methods and fields
+    '''
+
+    @pytest.fixture(autouse=True)
+    def setup(self, db):
+        '''
+
+        '''
+        self.site_daily_metrics = [
+            SiteDailyMetricsFactory()
+        ]
+
+    def test_foo(self):
+        '''
+        Assert that SiteDailyMetricsFactory works by checking the object
+        created in this class's ``setup`` method.
+
+        '''
+        assert SiteDailyMetrics.objects.count() == 1
+
+
+    @pytest.mark.parametrize('rec', [
+        dict(
+            date_for=datetime.date(2018,02,02),
+            defaults=dict(
+                cumulative_active_user_count=11,
+                total_user_count=1,
+                course_count=1,
+                total_enrollment_count=1
+            ),
+        ),
+    ])
+    def test_create(self, rec):
+        '''Sanity check we can create the SiteDailyMetrics model
+
+        Create a second instance the way we'll do it in the production code.
+        Assert this is correct
+        '''
+
+        site_metrics, created = SiteDailyMetrics.objects.get_or_create(**rec)
+
+        assert created and site_metrics
+

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -87,7 +87,5 @@ class TestSiteDailyMetricsSerializer(object):
         assert dateutil_parse(data['created']) == self.site_daily_metrics.created
         assert dateutil_parse(data['modified']) == self.site_daily_metrics.modified
 
-        field_names = self.expected_results_keys - self.date_fields
-
         for field_name in (self.expected_results_keys - self.date_fields):
             assert data[field_name] == getattr(self.site_daily_metrics,field_name)

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -1,13 +1,21 @@
 '''
 Test the serializers in edx-figures
 
+
+
 '''
 
+from dateutil.parser import parse as dateutil_parse
 import pytest
 
-from edx_figures.serializers import UserIndexSerializer
+from django.db import models
+from edx_figures.models import SiteDailyMetrics
+from edx_figures.serializers import (
+    UserIndexSerializer,
+    SiteDailyMetricsSerializer,
+)
 
-from .factories import UserFactory
+from .factories import SiteDailyMetricsFactory, UserFactory
 
 @pytest.mark.django_db
 class TestUserIndexSerializer(object):
@@ -39,3 +47,47 @@ class TestUserIndexSerializer(object):
         # This is to make sure that the serializer retrieves the correct nested
         # model (UserProfile) data
         assert data['fullname'] == 'Alpha One'
+
+
+@pytest.mark.django_db
+class TestSiteDailyMetricsSerializer(object):
+
+    @pytest.fixture(autouse=True)
+    def setup(self, db):
+        '''
+
+        '''
+        self.date_fields = set(['date_for', 'created', 'modified',])
+        self.expected_results_keys = set([o.name for o in SiteDailyMetrics._meta.fields])
+        field_names = (o.name for o in SiteDailyMetrics._meta.fields
+            if o.name not in self.date_fields )
+        self.site_daily_metrics = SiteDailyMetricsFactory()
+        self.serializer = SiteDailyMetricsSerializer(
+            instance=self.site_daily_metrics)
+
+    @pytest.mark.skip(reason='Test not implemented yet')
+    def test_time_zone(self):
+        pass
+
+    def test_has_fields(self):
+        '''Verify the serialized data has the same keys and values as the model
+
+        Django 2.0 has a convenient method, 'Cast' that will simplify converting
+        values:
+        https://docs.djangoproject.com/en/2.0/ref/models/database-functions/#cast
+
+        This means that we can retrieve the model instance values as a dict
+        and do a simple ``assert self.serializer.data == queryset.values(...)``
+        '''
+
+        data = self.serializer.data
+
+        # Hack: Check date and datetime values explicitly
+        assert data['date_for'] == str(self.site_daily_metrics.date_for)
+        assert dateutil_parse(data['created']) == self.site_daily_metrics.created
+        assert dateutil_parse(data['modified']) == self.site_daily_metrics.modified
+
+        field_names = self.expected_results_keys - self.date_fields
+
+        for field_name in (self.expected_results_keys - self.date_fields):
+            assert data[field_name] == getattr(self.site_daily_metrics,field_name)

--- a/tests/views/test_site_daily_metrics_view.py
+++ b/tests/views/test_site_daily_metrics_view.py
@@ -1,0 +1,121 @@
+'''Unit tests for the site daily metrics view
+
+'''
+
+import datetime
+from dateutil.parser import parse
+from dateutil.rrule import rrule, DAILY
+import pytest
+
+from rest_framework.test import (
+    APIRequestFactory,
+    #RequestsClient, Not supported in older  rest_framework versions
+    force_authenticate,
+    )
+
+from edx_figures.models import SiteDailyMetrics
+from edx_figures.views import SiteDailyMetricsViewSet
+
+from ..factories import SiteDailyMetricsFactory, UserFactory
+
+TEST_DATA = [
+    {}
+
+]
+
+def generate_sdm_series(first_day, last_day):
+
+    return [SiteDailyMetricsFactory(date_for=dt) 
+        for dt in rrule(DAILY, dtstart=first_day, until=last_day)]
+
+
+@pytest.mark.django_db
+class TestSiteDailyMetricsView(object):
+    '''
+
+    Note: This test class duplicates some of the code in 
+        test_serializers.TestSiteDailyMetricsSerializer
+
+    We might want to do the date handling/comparing code as a mix-in
+
+    TODO: AFter we finish and commit the view test for this, set the serialization
+    type for the dates. This should simplify this a lot 
+    # http://www.django-rest-framework.org/api-guide/fields/#date-and-time-fields
+
+    '''
+    @pytest.fixture(autouse=True)
+    def setup(self, db):
+        self.first_day = parse('2018-01-01')
+        self.last_day = parse('2018-03-31')
+        self.date_fields = set(['date_for', 'created', 'modified',])
+        self.expected_results_keys = set([o.name for o in SiteDailyMetrics._meta.fields])
+        field_names = (o.name for o in SiteDailyMetrics._meta.fields
+            if o.name not in self.date_fields )
+
+        self.metrics = generate_sdm_series(self.first_day, self.last_day)
+
+    def test_get_last_day(self):
+        pass
+
+    @pytest.mark.parametrize('first_day, last_day', [
+        ('2018-02-01', '2018-02-28'),
+    ])
+    def test_get_by_date_range(self, first_day, last_day):
+        '''
+        Note: This test is sensitive in the order data are compared. It expects
+        that records are retrieved by date_for, descending.
+
+        TODO: Add more date ranges
+        '''
+        first_day='2018-02-01'
+        last_day='2018-02-28'
+        endpoint = 'api/site-daily-metrics/?date_0={}&date_1={}'.format(
+            first_day, last_day)
+
+        expected_data = SiteDailyMetrics.objects.filter(
+            date_for__range=(first_day, last_day))
+        factory = APIRequestFactory()
+        request = factory.get(endpoint)
+        force_authenticate(request, user=UserFactory())
+        view = SiteDailyMetricsViewSet.as_view({'get':'list'})
+        response = view(request)
+        assert response.status_code == 200
+        assert len(response.data) == expected_data.count()
+
+        # Hack: Check date and datetime values explicitly
+        for data in response.data:
+            db_rec = expected_data.get(id=data['id'])
+            assert data['date_for'] == str(db_rec.date_for)
+            assert parse(data['created']) == db_rec.created
+            assert parse(data['modified']) == db_rec.modified
+
+        field_names = self.expected_results_keys - self.date_fields
+
+        for field_name in (self.expected_results_keys - self.date_fields):
+            assert data[field_name] == getattr(db_rec,field_name)
+
+    @pytest.mark.parametrize('data', [
+        ( dict(
+            date_for='2020-01-01',
+            cumulative_active_user_count=1,
+            todays_active_user_count=2,
+            total_user_count=3,
+            course_count=4,
+            total_enrollment_count=5
+            )
+        ),
+    ])
+    def test_create(self, data):
+        factory = APIRequestFactory()
+
+        # Might not need to set format='json'
+        request = factory.post('api/site-daily-metrics/', data, format='json')
+        force_authenticate(request, user=UserFactory())
+        view = SiteDailyMetricsViewSet.as_view({'post': 'create'})
+        
+        response = view(request)
+
+        assert response.status_code == 201
+        assert 'id' in response.data.keys()
+        for key in data.keys():
+            assert response.data[key] == data[key]

--- a/tests/views/test_site_daily_metrics_view.py
+++ b/tests/views/test_site_daily_metrics_view.py
@@ -16,7 +16,7 @@ from rest_framework.test import (
 from edx_figures.models import SiteDailyMetrics
 from edx_figures.views import SiteDailyMetricsViewSet
 
-from ..factories import SiteDailyMetricsFactory, UserFactory
+from tests.factories import SiteDailyMetricsFactory, UserFactory
 
 TEST_DATA = [
     {}

--- a/tests/views/test_user_index_view.py
+++ b/tests/views/test_user_index_view.py
@@ -17,7 +17,7 @@ from edx_figures.views import (
     UserIndexView,
     )
 
-from ..factories import UserFactory
+from tests.factories import UserFactory
 
 USER_DATA = [
     {'id': 1, 'username': u'alpha', 'fullname': u'Alpha One',


### PR DESCRIPTION
Added SiteDailyMetrics model, serializer, filter, view and tests

"Cleanliness" in testing issue: retrieving 'values' for a query set retain the `date time.datetime` and `date time.date` objects in the resulting values, therefore I converted the serialized dates to a datetime or date object to compare in the tests (see `test_site_daily_metrics_view.py` and `test_serializers.py`

I know there is a clean solution in Django 2.0 and documented that in `test_serializers.py`

Just to note, I'm not going for exhaustive testing at this point, really just to get a well rounded base for the different parts of the code to make additional test writing much faster

And hey! We've now got only 15 files in this review. Down 5 from last review!

Also note that this branch is to merge into `john/user-index`, which is to merge into `develop`. This is because I'm chaining the branches to avoid extra work in duplicating support code